### PR TITLE
Add verbose and silent flags

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -2,6 +2,15 @@
 
 Here's a comprehensive reference of all available commands:
 
+## Global Flags
+
+Use these flags with any command:
+
+```bash
+--verbose  # Enable debug logging
+--silent   # Suppress all console output
+```
+
 ## Parse PRD
 
 ```bash

--- a/scripts/modules/ui.js
+++ b/scripts/modules/ui.js
@@ -397,6 +397,47 @@ function displayHelp() {
 		})
 	);
 
+	// Display global flags
+	console.log(
+		boxen(chalk.green.bold('Global Flags'), {
+			padding: { left: 2, right: 2, top: 0, bottom: 0 },
+			margin: { top: 0, bottom: 0 },
+			borderColor: 'green',
+			borderStyle: 'round'
+		})
+	);
+
+	const flagTable = new Table({
+		colWidths: [20, Math.max(40, terminalWidth - 30)],
+		chars: {
+			top: '',
+			'top-mid': '',
+			'top-left': '',
+			'top-right': '',
+			bottom: '',
+			'bottom-mid': '',
+			'bottom-left': '',
+			'bottom-right': '',
+			left: '',
+			'left-mid': '',
+			mid: '',
+			'mid-mid': '',
+			right: '',
+			'right-mid': '',
+			middle: ' '
+		},
+		style: { border: [], 'padding-left': 4 },
+		wordWrap: true
+	});
+
+	flagTable.push(
+		['--verbose', 'Enable debug logging'],
+		['--silent', 'Suppress all console output']
+	);
+
+	console.log(flagTable.toString());
+	console.log('');
+
 	// Command categories
 	const commandCategories = [
 		{

--- a/scripts/modules/utils.js
+++ b/scripts/modules/utils.js
@@ -17,6 +17,16 @@ import {
 
 // Global silent mode flag
 let silentMode = false;
+// Global verbose mode flag
+let verboseMode = false;
+
+// Check CLI flags for verbosity or silence
+if (process.argv.includes('--silent')) {
+	silentMode = true;
+}
+if (process.argv.includes('--verbose')) {
+	verboseMode = true;
+}
 
 // --- Environment Variable Resolution Utility ---
 /**
@@ -130,10 +140,32 @@ function enableSilentMode() {
 }
 
 /**
+ * Enable verbose logging mode
+ */
+function enableVerboseMode() {
+	verboseMode = true;
+}
+
+/**
  * Disable silent logging mode
  */
 function disableSilentMode() {
 	silentMode = false;
+}
+
+/**
+ * Disable verbose logging mode
+ */
+function disableVerboseMode() {
+	verboseMode = false;
+}
+
+/**
+ * Check if verbose mode is enabled
+ * @returns {boolean} True if verbose mode is enabled
+ */
+function isVerboseMode() {
+	return verboseMode;
 }
 
 /**
@@ -165,6 +197,11 @@ function log(level, ...args) {
 		// If getLogLevel() fails (likely due to circular dependency),
 		// use default 'info' level and continue
 		configLevel = 'info';
+	}
+
+	// Override with verbose mode if set
+	if (verboseMode) {
+		configLevel = 'debug';
 	}
 
 	// Use text prefixes instead of emojis
@@ -678,9 +715,12 @@ export {
 	toKebabCase,
 	detectCamelCaseFlags,
 	disableSilentMode,
+	disableVerboseMode,
 	enableSilentMode,
+	enableVerboseMode,
 	getTaskManager,
 	isSilentMode,
+	isVerboseMode,
 	addComplexityToTask,
 	resolveEnvVariable,
 	findProjectRoot,


### PR DESCRIPTION
## Summary
- support `--verbose` and `--silent` flags when parsing options
- show these flags in CLI help output
- document `--verbose` and `--silent` in the command reference

## Testing
- `npm run format-check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845b0a79b108328a8e4c844e92dd00c