### PR TITLE
Document default PRD path

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ This will prompt you for project details and set up a new project with the neces
 task-master init
 
 # Parse a PRD and generate tasks
-task-master parse-prd your-prd.txt
+task-master parse-prd
 
 # List all tasks
 task-master list
@@ -182,6 +182,9 @@ task-master next
 # Generate task files
 task-master generate
 ```
+
+Tip: `parse-prd` automatically checks `.taskmaster/docs/prd.txt`. Use the
+`--input` flag only when your PRD is in a different location.
 
 ## Documentation
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -12,6 +12,10 @@ task-master parse-prd <prd-file.txt>
 task-master parse-prd <prd-file.txt> --num-tasks=10
 ```
 
+By default, this command looks for `.taskmaster/docs/prd.txt`. Use the
+`--input` flag or a positional file argument only if your PRD is stored in a
+different location.
+
 ## List Tasks
 
 ```bash

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -100,7 +100,7 @@ After setting up Task Master, you can use these commands (either via AI prompts 
 
 ```bash
 # Parse a PRD and generate tasks
-task-master parse-prd your-prd.txt
+task-master parse-prd
 
 # List all tasks
 task-master list
@@ -111,6 +111,9 @@ task-master next
 # Generate task files
 task-master generate
 ```
+
+The `parse-prd` command looks for `.taskmaster/docs/prd.txt` by default. Provide
+`--input` or a file argument only when your PRD lives elsewhere.
 
 ## Setting up Cursor AI Integration
 
@@ -163,6 +166,9 @@ The agent will execute:
 ```bash
 task-master parse-prd .taskmaster/docs/prd.txt
 ```
+
+You can omit the file path here because `parse-prd` searches for
+`.taskmaster/docs/prd.txt` automatically.
 
 This will:
 


### PR DESCRIPTION
## Summary
- document `.taskmaster/docs/prd.txt` as the default PRD path
- clarify when to use `--input` in docs and README

## Testing
- `npm run format-check` *(fails: biome not found)*
- `npm test` *(fails: jest module not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b0a8acc883288bed9a8d7fbe4761